### PR TITLE
feat: rewrite relative links when sections move directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,16 @@ sudo reboot
 
 The contents of the section that was moved will also be removed from the original notes file, in this case `2025-01-20.md`.
 
+### Relative Link Handling
+
+Whenever a section is moved to a file in a different folder — extracted into a document, merged into a combined file, or rolled over into a new week's entry — its Markdown file links (`[text](./path)` and `![alt](./path)`) are adjusted so they still resolve to the same file from the new location:
+
+- **Relative file links** are re-based on the directory change (e.g. `./attachments/spec.pdf` becomes `../notes/2025-01-20_2025-01-26/attachments/spec.pdf`).
+- **Anchor links** (`[text](#heading)`) are handled by whether the heading moved with them. If the target heading is inside the moved section it is left as-is. If the heading stayed behind in the original file, the anchor is rewritten into a cross-file link back to that file (e.g. `#work-done` becomes `../notes/2025-01-20_2025-01-26/2025-01-20.md#work-done`). Anchors are matched to headings using GitHub-style slugs.
+- **Absolute paths, `~/` home paths, and URLs** are left untouched.
+
+Links in the `summary.md` file are unaffected, since it is written into the same folder as the entries.
+
 ## Merge
 
 Use the `merge` command to combine all markdown files from a folder into a single markdown file. Unlike `collate`, the merge command:

--- a/enheduanna/cli.py
+++ b/enheduanna/cli.py
@@ -10,6 +10,7 @@ from enheduanna.types.markdown.markdown_section import MarkdownSection
 
 from enheduanna.utils.collation import create_parent_folder
 from enheduanna.utils.files import list_markdown_files, find_last_markdown_file, normalize_file_name
+from enheduanna.utils.links import rewrite_section_links
 from enheduanna.utils.markdown import generate_markdown_collation, generate_markdown_merge, remove_empty_sections
 from enheduanna.utils.media import organize_media_for_collation, update_markdown_media_references, parse_collation_folder_name
 
@@ -32,6 +33,11 @@ def ensure_entry_file(parent_folder: Path, today: date, config: Config,
         if last_markdown_file and section.rollover:
             existing_section = last_markdown_file.root_section.remove_section(section.title)
             if existing_section:
+                # Relative links resolve against the source file's dir; fix them for the new location.
+                # The section is already removed from last_markdown_file, so its remaining root
+                # holds the headings that stayed behind (for cross-file anchor rewriting).
+                rewrite_section_links(existing_section, last_markdown_file.file_path, parent_folder,
+                                      last_markdown_file.root_section)
                 markdown_contents.add_section(existing_section)
                 last_markdown_file.write()
                 continue
@@ -85,7 +91,7 @@ def collate(context: click.Context, file_dir: str, title, collate_name: str):
         markdown_files.append(MarkdownFile.from_file(path))
     # Ignore sections set automatically but not in collate
     ignore_sections = set(i.title for i in context.obj.file.entry_sections) - set([i.title for i in context.obj.file.collate_sections]) #pylint:disable=consider-using-set-comprehension
-    combos, documents = generate_markdown_collation(markdown_files, context.obj.file.collate_sections, ignore_sections)
+    combos, documents = generate_markdown_collation(markdown_files, context.obj.file.collate_sections, ignore_sections, context.obj.file.document_folder)
     new_document = MarkdownSection(title, '')
     for section in combos:
         section.level = 2
@@ -124,7 +130,7 @@ def merge(file_dir: str, output_file: str, title):
     # Include all markdown files, not just entries
     for path in list_markdown_files(file_dir, only_include_entry=False):
         markdown_files.append(MarkdownFile.from_file(path))
-    merged_section = generate_markdown_merge(markdown_files, title)
+    merged_section = generate_markdown_merge(markdown_files, title, output_file.parent)
     output_file.write_text(merged_section.write())
     click.echo(f'Merged data written to file {output_file}')
 

--- a/enheduanna/types/markdown/markdown_file.py
+++ b/enheduanna/types/markdown/markdown_file.py
@@ -30,9 +30,17 @@ def find_header(line_input: str) -> int:
     '''
     Find header if it exists in line and returns level
 
+    Only counts leading '#' characters that form an ATX heading (followed by a
+    space or end of line), so inline '#' such as anchor links do not register.
+
     line_input : Line that was inputed
     '''
-    return len(line_input) - len(line_input.replace('#', ''))
+    stripped = line_input.lstrip()
+    level = len(stripped) - len(stripped.lstrip('#'))
+    # Not a heading unless the leading '#'s are followed by a space or nothing
+    if level == 0 or stripped[level:level + 1] not in ('', ' '):
+        return 0
+    return level
 
 def generate_markdown_sections(markdown_text: str, current_tab: int = 1) -> List[MarkdownSection]:
     '''

--- a/enheduanna/utils/links.py
+++ b/enheduanna/utils/links.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+from re import match, sub
+import os
+
+from enheduanna.types.markdown.markdown_section import MarkdownSection
+
+# Matches markdown inline links and images: [text](target) and ![alt](target)
+LINK_REGEX = r'(!?\[[^\]]*\]\()([^)]+)(\))'
+# Matches a URL scheme prefix like http:, https:, mailto:
+SCHEME_REGEX = r'^[a-z][a-z0-9+.-]*:'
+
+
+def _slugify(title: str) -> str:
+    '''
+    Convert a heading title into a GitHub-style anchor slug
+
+    title : Heading title
+    '''
+    slug = title.strip().lower()
+    slug = sub(r'[^\w\s-]', '', slug)
+    slug = sub(r'\s+', '-', slug)
+    return slug
+
+
+def _collect_slugs(section: MarkdownSection) -> set:
+    '''
+    Collect anchor slugs for a section and all of its subsections
+
+    section : MarkdownSection
+    '''
+    slugs = {_slugify(section.title)}
+    for subsection in section.sections:
+        slugs |= _collect_slugs(subsection)
+    return slugs
+
+
+def _split_suffixes(target: str) -> tuple:
+    '''
+    Split a link target into (path, anchor, title) suffixes
+
+    target : Raw link target, may include "#anchor" and/or a "title"
+    '''
+    target = target.strip()
+    title = ''
+    for quote in ('"', "'"):
+        idx = target.find(f' {quote}')
+        if idx != -1:
+            title = target[idx:]
+            target = target[:idx]
+            break
+    anchor = ''
+    if '#' in target:
+        target, _, rest = target.partition('#')
+        anchor = f'#{rest}'
+    return target, anchor, title
+
+
+def _rewrite_target(target: str, source_file: Path, dest_dir: Path,
+                    moved_slugs: set, stayed_slugs: set) -> str:
+    '''
+    Rewrite a single link target so it resolves to the same file after moving
+    from source_file's directory to dest_dir. Leaves non-relative targets alone.
+
+    target : Raw link target, may include "#anchor" and/or a "title" suffix
+    source_file : File the content is moving from
+    dest_dir : Directory the content is moving to
+    moved_slugs : Anchor slugs that moved along with the content
+    stayed_slugs : Anchor slugs that stayed behind in the source file
+    '''
+    path, anchor, title = _split_suffixes(target)
+    source_dir = source_file.parent
+    # Anchor-only link ([x](#heading)) into the same document
+    if not path and anchor:
+        slug = anchor.lstrip('#').lower()
+        # Heading moved along with the link, or exists nowhere: leave as-is
+        if slug in moved_slugs or slug not in stayed_slugs:
+            return f'{anchor}{title}'
+        # Heading stayed behind: point back at the source file
+        new_path = os.path.relpath(source_file, dest_dir)
+        return f'{new_path}{anchor}{title}'
+    # Schemes, absolute paths, home paths, and empty targets are left alone
+    if not path or path.startswith(('/', '~')) or match(SCHEME_REGEX, path):
+        return f'{path}{anchor}{title}'
+    # Relative file link: only recompute when the directory actually changes
+    if source_dir.resolve() == dest_dir.resolve():
+        return f'{path}{anchor}{title}'
+    new_path = os.path.relpath(source_dir / path, dest_dir)
+    return f'{new_path}{anchor}{title}'
+
+
+def rewrite_relative_links(content: str, source_file: Path, dest_dir: Path,
+                           moved_slugs: set = frozenset(), stayed_slugs: set = frozenset()) -> str:
+    '''
+    Rewrite relative file links in markdown content so they resolve to the same
+    target after moving the content from source_file's directory to dest_dir.
+
+    content : Markdown content
+    source_file : File the content is moving from
+    dest_dir : Directory the content is moving to
+    moved_slugs : Anchor slugs that moved along with the content
+    stayed_slugs : Anchor slugs that stayed behind in the source file
+    '''
+    source_file = Path(source_file)
+    dest_dir = Path(dest_dir)
+
+    def _replace(matcher):
+        prefix = matcher.group(1)
+        target = matcher.group(2)
+        suffix = matcher.group(3)
+        new_target = _rewrite_target(target, source_file, dest_dir, moved_slugs, stayed_slugs)
+        return f'{prefix}{new_target}{suffix}'
+
+    return sub(LINK_REGEX, _replace, content)
+
+
+def rewrite_section_links(section: MarkdownSection, source_file: Path, dest_dir: Path,
+                          source_root: MarkdownSection = None) -> None:
+    '''
+    Rewrite relative links in a section and all of its subsections in place.
+
+    Relative file links are re-based on the directory change. Anchor-only links
+    are rewritten into cross-file links when the heading they point at stayed
+    behind in the source file rather than moving along with the section.
+
+    section : MarkdownSection whose contents are moving directories
+    source_file : File the section came from
+    dest_dir : Directory the section is moving to
+    source_root : Root section remaining in the source file, used to detect
+                  headings that stayed behind (None to skip anchor rewriting)
+    '''
+    source_file = Path(source_file)
+    dest_dir = Path(dest_dir)
+    moved_slugs = _collect_slugs(section)
+    stayed_slugs = _collect_slugs(source_root) if source_root is not None else frozenset()
+    _rewrite_section(section, source_file, dest_dir, moved_slugs, stayed_slugs)
+
+
+def _rewrite_section(section: MarkdownSection, source_file: Path, dest_dir: Path,
+                     moved_slugs: set, stayed_slugs: set) -> None:
+    '''
+    Recursively rewrite links in a section using pre-computed slug sets
+    '''
+    section.contents = rewrite_relative_links(section.contents, source_file, dest_dir, moved_slugs, stayed_slugs)
+    for subsection in section.sections:
+        _rewrite_section(subsection, source_file, dest_dir, moved_slugs, stayed_slugs)

--- a/enheduanna/utils/markdown.py
+++ b/enheduanna/utils/markdown.py
@@ -1,10 +1,12 @@
 from copy import deepcopy
 from json import dumps
+from pathlib import Path
 from typing import List, Tuple
 
 from enheduanna.types.markdown.markdown_file import MarkdownFile
 from enheduanna.types.markdown.markdown_section import MarkdownSection
 from enheduanna.types.markdown.collate_section import CollateSection
+from enheduanna.utils.links import rewrite_section_links
 
 def section_generate_from_json(data_input: List[dict]) -> List[MarkdownSection]:
     '''
@@ -30,7 +32,8 @@ def collate_section_generate_from_json(data_input: List[dict]) -> List[CollateSe
 
 def _gather_all_section_data(markdown_file: MarkdownFile, parent_section: MarkdownSection,
                              collate_sections: List[str], ignore_sections: List[str],
-                             collate_mapping: dict, document_list: list) -> bool:
+                             collate_mapping: dict, document_list: list,
+                             document_folder: Path) -> bool:
     '''
     Recursively gather all section data in collate section names
 
@@ -39,6 +42,7 @@ def _gather_all_section_data(markdown_file: MarkdownFile, parent_section: Markdo
     markdown_sections: Sections within parent
     collate_sections: Collate sections to run
     ignore_sections: Ignore these sections for doc collation
+    document_folder: Destination folder for extracted document sections
 
     collate_mapping/document_list: Kept here for loop to return in main function
     '''
@@ -63,30 +67,36 @@ def _gather_all_section_data(markdown_file: MarkdownFile, parent_section: Markdo
             if section.level > 1:
                 doc_sections.append(section.title)
                 continue
-            _gather_all_section_data(markdown_file, section, collate_sections, ignore_sections, collate_mapping, document_list)
+            _gather_all_section_data(markdown_file, section, collate_sections, ignore_sections, collate_mapping, document_list, document_folder)
     # Remove these at the end since it cant muck with the order of sections
     for title in doc_sections:
         document_section = parent_section.remove_section(title)
         markdown_file.write()
-        document_list.append(document_section.generate_root(prefix=f'{markdown_file.root_section.title} '))
+        new_root = document_section.generate_root(prefix=f'{markdown_file.root_section.title} ')
+        # Relative links resolve against the source file's dir; fix them for the new location.
+        # Pass the (already-trimmed) source root so anchors to headings that stayed behind
+        # become cross-file links.
+        rewrite_section_links(new_root, markdown_file.file_path, document_folder, markdown_file.root_section)
+        document_list.append(new_root)
 
     return True
 
 def generate_markdown_collation(markdown_files: List[MarkdownFile], collate_sections: List[CollateSection],
-                             ignore_sections: List[str]) -> Tuple[List[MarkdownSection], List[MarkdownSection]]:
+                             ignore_sections: List[str], document_folder: Path) -> Tuple[List[MarkdownSection], List[MarkdownSection]]:
     '''
     Combine markdown sections by the collate titles
 
     markdown_sections: Sections of markdown
     collate_sections: List of collate sections
     ignore_sections: Ignore sections when making new documents
+    document_folder: Destination folder for extracted document sections
 
     returns tupe of [List of combined sections] [List of document sections]
     '''
     section_mapping = {}
     document_list = []
     for markdown_file in markdown_files:
-        _gather_all_section_data(markdown_file, markdown_file.root_section, collate_sections, ignore_sections, section_mapping, document_list)
+        _gather_all_section_data(markdown_file, markdown_file.root_section, collate_sections, ignore_sections, section_mapping, document_list, document_folder)
     new_sections = []
     for _key, values in section_mapping.items():
         section = values['section']
@@ -105,13 +115,14 @@ def __remove_empty(markdown_file: MarkdownFile, parent_section: MarkdownSection)
         parent_section.remove_section(remove)
     return True
 
-def generate_markdown_merge(markdown_files: List[MarkdownFile], title: str) -> MarkdownSection:
+def generate_markdown_merge(markdown_files: List[MarkdownFile], title: str, output_dir: Path) -> MarkdownSection:
     '''
     Merge all markdown files into a single section, with each file becoming a section
     and all subsections increased by 1 level
 
     markdown_files: List of markdown files to merge
     title: Title for the merged document
+    output_dir: Destination folder for the merged file
 
     returns merged MarkdownSection
     '''
@@ -120,6 +131,9 @@ def generate_markdown_merge(markdown_files: List[MarkdownFile], title: str) -> M
     for markdown_file in markdown_files:
         # Create a copy of the root section from the file
         file_section = deepcopy(markdown_file.root_section)
+        # Relative links resolve against the source file's dir; fix them for the new location.
+        # The whole file moves, so every same-file anchor moves with it (no stayed-behind root).
+        rewrite_section_links(file_section, markdown_file.file_path, output_dir)
         # Increase level to 2 (from 1) and all subsections accordingly
         file_section.level = 2
         file_section.set_section_levels(3)

--- a/tests/types/markdown/test_markdown_file.py
+++ b/tests/types/markdown/test_markdown_file.py
@@ -1,7 +1,37 @@
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from enheduanna.types.markdown.markdown_file import MarkdownFile
+from enheduanna.types.markdown.markdown_file import MarkdownFile, find_header
+
+def test_find_header_ignores_inline_hash():
+    # A leading ATX header still counts
+    assert find_header('## Work Done') == 2
+    assert find_header('# Title') == 1
+    # Inline '#' (anchor links, comments) must not register as a header
+    assert find_header('See [work](#work-done) and [detail](#detail)') == 0
+    assert find_header('- item with a # in it') == 0
+    # '#' not followed by a space is not an ATX header
+    assert find_header('#notaheader') == 0
+
+def test_markdown_section_keeps_anchor_link_line_as_contents():
+    input_text = '''# 2025-01-01
+
+## Steps
+
+See [work](#work-done) for context
+
+### Detail
+
+more'''
+    with NamedTemporaryFile() as tmp:
+        path = Path(tmp.name)
+        path.write_text(input_text)
+        mf = MarkdownFile.from_file(path)
+        steps = mf.root_section.sections[0]
+        assert steps.title == 'Steps'
+        # The anchor-link line stays as contents rather than becoming a section title
+        assert steps.contents == 'See [work](#work-done) for context'
+        assert steps.sections[0].title == 'Detail'
 
 def test_markdown_section_from_text():
     input_text = '''# 2025-01-01

--- a/tests/utils/test_links.py
+++ b/tests/utils/test_links.py
@@ -1,0 +1,124 @@
+from pathlib import Path
+
+from enheduanna.types.markdown.markdown_section import MarkdownSection
+from enheduanna.utils.links import rewrite_relative_links, rewrite_section_links
+
+
+def test_rewrite_moves_relative_link_up_a_dir():
+    # Content moves from notes/week1/ down to documents/; a sibling link must gain '../'
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = 'See [spec](./attachments/spec.pdf) for details'
+    result = rewrite_relative_links(content, source, dest)
+    assert result == 'See [spec](../notes/week1/attachments/spec.pdf) for details'
+
+
+def test_rewrite_parent_relative_link():
+    # A link to a shared sibling folder must stay pointed at the same target
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/notes/week2')
+    content = '[shared](../shared/notes.md)'
+    result = rewrite_relative_links(content, source, dest)
+    assert result == '[shared](../shared/notes.md)'
+
+
+def test_rewrite_image_link():
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = '![diagram](./media/diagram.png)'
+    result = rewrite_relative_links(content, source, dest)
+    assert result == '![diagram](../notes/week1/media/diagram.png)'
+
+
+def test_preserves_anchor_and_title_on_file_link():
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = '[x](./doc.md#section "A Title")'
+    result = rewrite_relative_links(content, source, dest)
+    assert result == '[x](../notes/week1/doc.md#section "A Title")'
+
+
+def test_skips_non_relative_targets():
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = (
+        '[web](https://example.com/page) '
+        '[mail](mailto:me@example.com) '
+        '[abs](/etc/hosts) '
+        '[home](~/notes/x.md)'
+    )
+    # Nothing relative to a file, so nothing should change
+    assert rewrite_relative_links(content, source, dest) == content
+
+
+def test_same_dir_leaves_file_links_alone():
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/notes/week1')
+    content = '[x](./attachments/spec.pdf)'
+    assert rewrite_relative_links(content, source, dest) == content
+
+
+def test_anchor_left_alone_when_heading_moved_along():
+    # #setup points at a heading inside the moved content -> still resolves
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = '[jump](#setup)'
+    result = rewrite_relative_links(content, source, dest, moved_slugs={'setup'})
+    assert result == '[jump](#setup)'
+
+
+def test_anchor_rewritten_when_heading_stayed_behind():
+    # #setup points at a heading that stayed in the source file -> cross-file link
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = '[jump](#setup)'
+    result = rewrite_relative_links(content, source, dest, stayed_slugs={'setup'})
+    assert result == '[jump](../notes/week1/2025-01-01.md#setup)'
+
+
+def test_anchor_left_alone_when_heading_absent():
+    # #setup is not a heading anywhere in the source -> already dangling, leave it
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    content = '[jump](#setup)'
+    result = rewrite_relative_links(content, source, dest)
+    assert result == '[jump](#setup)'
+
+
+def test_anchor_rewritten_within_same_dir_different_file():
+    # A same-dir move to a different file still orphans a stayed-behind anchor
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/notes/week1')
+    content = '[jump](#setup)'
+    result = rewrite_relative_links(content, source, dest, stayed_slugs={'setup'})
+    assert result == '[jump](2025-01-01.md#setup)'
+
+
+def test_rewrite_section_links_uses_moved_and_stayed_headings():
+    # Moved subtree owns 'Details'; source file keeps 'Setup'
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+
+    moved = MarkdownSection('Reboot Steps', '[a](#details) and [b](#setup)', level=1)
+    moved.add_section(MarkdownSection('Details', 'stuff', level=2))
+
+    stayed = MarkdownSection('2025-01-01', '', level=1)
+    stayed.add_section(MarkdownSection('Setup', 'env notes', level=2))
+
+    rewrite_section_links(moved, source, dest, stayed)
+
+    # #details moved along -> unchanged; #setup stayed behind -> cross-file
+    assert moved.contents == '[a](#details) and [b](../notes/week1/2025-01-01.md#setup)'
+
+
+def test_rewrite_section_links_recurses_file_links():
+    source = Path('/base/notes/week1/2025-01-01.md')
+    dest = Path('/base/documents')
+    root = MarkdownSection('Root', '[a](./a.md)', level=1)
+    child = MarkdownSection('Child', '[b](./nested/b.md)', level=2)
+    root.add_section(child)
+
+    rewrite_section_links(root, source, dest)
+
+    assert root.contents == '[a](../notes/week1/a.md)'
+    assert root.sections[0].contents == '[b](../notes/week1/nested/b.md)'

--- a/tests/utils/test_markdown.py
+++ b/tests/utils/test_markdown.py
@@ -57,7 +57,7 @@ def test_combine_markdown_sections():
 
         mf1 = MarkdownFile(path1, ms1)
         mf2 = MarkdownFile(path2, ms2)
-        result, document = generate_markdown_collation([mf1, mf2], [cs1], ['Follow Ups'])
+        result, document = generate_markdown_collation([mf1, mf2], [cs1], ['Follow Ups'], Path(tmpdir) / 'documents')
         assert len(result) == 1
         assert len(document) == 2
         assert result[0].title == 'Work Done'
@@ -103,7 +103,7 @@ def test_merge_markdown_sections():
         mf2 = MarkdownFile(path2, doc2)
         mf3 = MarkdownFile(path3, doc3)
 
-        result = generate_markdown_merge([mf1, mf2, mf3], 'Combined Operations Runbook')
+        result = generate_markdown_merge([mf1, mf2, mf3], 'Combined Operations Runbook', docs_dir)
 
         assert result.title == 'Combined Operations Runbook'
         assert result.level == 1
@@ -152,7 +152,7 @@ def test_combine_markdown_sections_recursive():
     with TemporaryDirectory() as tmpdir:
         path = Path(tmpdir) / '2025-02-10.md'
         mf = MarkdownFile(path, outer)
-        result, _ = generate_markdown_collation([mf], [cs], [])
+        result, _ = generate_markdown_collation([mf], [cs], [], Path(tmpdir) / 'documents')
         assert len(result) == 1
         assert result[0].title == 'Work Done'
 


### PR DESCRIPTION
## Summary

When `collate`, `merge`, or `new-entry` rollover relocate a section's content to a file in a different folder, relative Markdown links in that content silently break because they were resolved against the source file's directory. This rewrites them to resolve to the same target from the new location.

## What it does

Adds `enheduanna/utils/links.py` (`rewrite_relative_links` / `rewrite_section_links`), wired into the three move sites:
- **collate** document extraction — source file → `document_folder`
- **merge** — source file → output file's dir
- **new-entry** rollover — last week's file → new week's folder

Behavior (inline `[text](path)` and `![alt](path)` only):
- **Relative file links** are re-based on the directory change, e.g. `./attachments/spec.pdf` → `../notes/2025-01-20_2025-01-26/attachments/spec.pdf`.
- **Anchor links** (`[text](#heading)`) depend on whether the heading moved along:
  - heading inside the moved section → left as-is
  - heading stayed behind in the source file → rewritten to a cross-file link, e.g. `#work-done` → `../notes/2025-01-20_2025-01-26/2025-01-20.md#work-done`
  - heading absent from the source → left alone (already dangling)
  - matched via GitHub-style slugs
- **Absolute paths, `~/` home paths, and URLs** are left untouched.

`summary.md` is unaffected since it stays in the entries folder.

## Parser fix (required for the above)

`find_header` in `markdown_file.py` counted *every* `#` in a line instead of only leading ATX `#`s. Any content line containing an anchor link (e.g. `See [work](#work-done)`) was misparsed as a heading and shredded at parse time — which broke round-tripping of exactly the links this feature manages. Now it only counts leading `#`s followed by a space/EOL.

## Known limitation

In the collate path the extracted section's own top title gets a date prefix (`Steps to Reboot Servers` → `2025-01-20 Steps to Reboot Servers`), changing its slug, so a self-referential anchor to *that* title isn't remapped. Anchors to subsections and to stayed-behind headings all work.

## Testing

- Full suite: **67 passed** (new `test_links.py` covering file-link re-basing + all three anchor cases + same-dir orphaning; new `find_header` regression tests)
- pylint: **10.00/10** on all changed source files
- End-to-end collation verified: `#work-done` → cross-file, `#detail` → unchanged, `./attachments/spec.pdf` → rebased

🤖 Generated with [Claude Code](https://claude.com/claude-code)